### PR TITLE
Add DataFusion plan nodes for preprocessing and embedding

### DIFF
--- a/rust/lancedb/src/data/preprocessing/mod.rs
+++ b/rust/lancedb/src/data/preprocessing/mod.rs
@@ -17,7 +17,11 @@
 mod nan_handling;
 mod schema_inference;
 
+pub(crate) use nan_handling::{
+    find_float_vector_columns, handle_nan_batch, nan_row_mask, nullify_fsl_rows,
+};
 pub use nan_handling::{handle_nan_vectors, NanStrategy};
+pub(crate) use schema_inference::{build_fsl_from_offsets, get_list_offsets_and_values};
 pub use schema_inference::{
     find_vector_candidates, infer_vector_schema, BadVectorStrategy, FieldPath,
 };

--- a/rust/lancedb/src/data/preprocessing/nan_handling.rs
+++ b/rust/lancedb/src/data/preprocessing/nan_handling.rs
@@ -48,7 +48,7 @@ fn is_float_element(inner: &Field) -> bool {
 }
 
 /// Find all top-level float vector columns (FixedSizeList, List, or LargeList).
-fn find_float_vector_columns(schema: &SchemaRef) -> Vec<usize> {
+pub fn find_float_vector_columns(schema: &SchemaRef) -> Vec<usize> {
     schema
         .fields()
         .iter()
@@ -132,7 +132,7 @@ fn fill_column_rows(col: &dyn Array, fill: f64) -> Result<ArrayRef> {
 }
 
 /// Process a single batch: detect and handle NaN values in float vector columns.
-fn handle_nan_batch(
+pub fn handle_nan_batch(
     batch: RecordBatch,
     vec_cols: &[usize],
     strategy: &NanStrategy,
@@ -220,7 +220,7 @@ fn any_nan_in_fsl(arr: &FixedSizeListArray) -> bool {
 /// Compute a per-row boolean mask indicating which rows contain NaN values.
 ///
 /// Needed by Drop and Null strategies to know exactly which rows are affected.
-fn nan_row_mask(arr: &FixedSizeListArray) -> BooleanArray {
+pub fn nan_row_mask(arr: &FixedSizeListArray) -> BooleanArray {
     let values = arr.values();
     let n = arr.len();
     let dim = arr.value_length() as usize;
@@ -454,7 +454,7 @@ fn fill_list_rows<O: OffsetSizeTrait>(arr: &dyn Array, fill: f64) -> Result<Arra
 }
 
 /// Replace NaN-containing rows with null by updating the validity bitmap.
-fn nullify_fsl_rows(fsl: &FixedSizeListArray, is_bad: &BooleanArray) -> Result<ArrayRef> {
+pub fn nullify_fsl_rows(fsl: &FixedSizeListArray, is_bad: &BooleanArray) -> Result<ArrayRef> {
     let n = fsl.len();
     let mut builder = NullBufferBuilder::new(n);
     for row in 0..n {

--- a/rust/lancedb/src/data/preprocessing/schema_inference.rs
+++ b/rust/lancedb/src/data/preprocessing/schema_inference.rs
@@ -491,7 +491,7 @@ fn convert_list_to_fsl(
 }
 
 /// Extract per-row offsets (as i64) and the flat values buffer from a list array.
-fn get_list_offsets_and_values(arr: &dyn Array) -> Result<(Vec<i64>, ArrayRef)> {
+pub fn get_list_offsets_and_values(arr: &dyn Array) -> Result<(Vec<i64>, ArrayRef)> {
     match arr.data_type() {
         DataType::List(_) => {
             let list = arr.as_list::<i32>();
@@ -510,7 +510,7 @@ fn get_list_offsets_and_values(arr: &dyn Array) -> Result<(Vec<i64>, ArrayRef)> 
 }
 
 /// Build a FixedSizeList from pre-cast flat values using list offsets.
-fn build_fsl_from_offsets<B: ArrowValueBuilder>(
+pub fn build_fsl_from_offsets<B: ArrowValueBuilder>(
     arr: &dyn Array,
     offsets: &[i64],
     cast_values: &B::ArrayType,
@@ -558,7 +558,7 @@ fn build_fsl_from_offsets<B: ArrowValueBuilder>(
 }
 
 /// Trait abstracting over Float32Builder and UInt8Builder for generic FSL construction.
-trait ArrowValueBuilder: ArrayBuilder {
+pub trait ArrowValueBuilder: ArrayBuilder {
     type ArrayType: Array;
 
     fn builder_with_capacity(capacity: usize) -> Self;

--- a/rust/lancedb/src/data/preprocessing/schema_inference.rs
+++ b/rust/lancedb/src/data/preprocessing/schema_inference.rs
@@ -589,6 +589,27 @@ impl ArrowValueBuilder for Float32Builder {
     }
 }
 
+impl ArrowValueBuilder for arrow_array::builder::Float64Builder {
+    type ArrayType = arrow_array::Float64Array;
+
+    fn builder_with_capacity(capacity: usize) -> Self {
+        Self::with_capacity(capacity)
+    }
+    fn append_nulls_n(builder: &mut Self, count: usize) {
+        builder.append_nulls(count);
+    }
+    fn append_fill(builder: &mut Self, count: usize, value: f64) {
+        for _ in 0..count {
+            builder.append_value(value);
+        }
+    }
+    fn copy_range(builder: &mut Self, source: &Self::ArrayType, start: usize, len: usize) {
+        for j in 0..len {
+            builder.append_value(source.value(start + j));
+        }
+    }
+}
+
 impl ArrowValueBuilder for UInt8Builder {
     type ArrayType = UInt8Array;
 

--- a/rust/lancedb/src/embeddings.rs
+++ b/rust/lancedb/src/embeddings.rs
@@ -86,6 +86,13 @@ pub trait EmbeddingRegistry: Send + Sync + std::fmt::Debug {
     fn register(&self, name: &str, function: Arc<dyn EmbeddingFunction>) -> Result<()>;
     /// Get an embedding function by name
     fn get(&self, name: &str) -> Option<Arc<dyn EmbeddingFunction>>;
+    /// Parse embedding definitions from schema metadata and resolve them against this registry.
+    fn parse_metadata_embeddings(
+        &self,
+        _schema: &SchemaRef,
+    ) -> Vec<(EmbeddingDefinition, Arc<dyn EmbeddingFunction>)> {
+        Vec::new()
+    }
 }
 
 /// A [`EmbeddingRegistry`] that uses in-memory [`HashMap`]s

--- a/rust/lancedb/src/table/datafusion.rs
+++ b/rust/lancedb/src/table/datafusion.rs
@@ -3,7 +3,10 @@
 
 //! This module contains adapters to allow LanceDB tables to be used as DataFusion table providers.
 
+pub mod cast_vector;
+pub mod embedding_udf;
 pub mod insert;
+pub mod preprocessing;
 pub mod udtf;
 
 use std::{collections::HashMap, sync::Arc};

--- a/rust/lancedb/src/table/datafusion/cast_vector.rs
+++ b/rust/lancedb/src/table/datafusion/cast_vector.rs
@@ -1,0 +1,630 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
+//! DataFusion physical expression and projection for casting vector columns to `FixedSizeList`.
+
+use std::any::Any;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+use arrow_array::cast::AsArray;
+use arrow_array::{Array, ArrayRef, FixedSizeListArray};
+use arrow_cast::cast;
+use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use datafusion_common::Result as DataFusionResult;
+
+type DFResult<T> = DataFusionResult<T>;
+use datafusion_expr::ColumnarValue;
+use datafusion_physical_expr::expressions::{CastExpr, Column};
+use datafusion_physical_expr::PhysicalExpr;
+use datafusion_physical_plan::projection::ProjectionExec;
+use datafusion_physical_plan::ExecutionPlan;
+
+use crate::data::preprocessing::{
+    build_fsl_from_offsets, get_list_offsets_and_values, nan_row_mask, nullify_fsl_rows,
+    BadVectorStrategy,
+};
+
+/// Casts `List`/`LargeList`/`FixedSizeList` columns to `FixedSizeList<T, N>`.
+#[derive(Debug, Clone, Eq)]
+pub struct CastToFixedSizeListExpr {
+    source: Arc<dyn PhysicalExpr>,
+    dimension: i32,
+    inner_type: DataType,
+}
+
+impl PartialEq for CastToFixedSizeListExpr {
+    fn eq(&self, other: &Self) -> bool {
+        self.source.eq(&other.source)
+            && self.dimension == other.dimension
+            && self.inner_type == other.inner_type
+    }
+}
+
+impl Hash for CastToFixedSizeListExpr {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.source.hash(state);
+        self.dimension.hash(state);
+        self.inner_type.hash(state);
+    }
+}
+
+impl fmt::Display for CastToFixedSizeListExpr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "CastToFSL({}, dim={}, inner={})",
+            self.source, self.dimension, self.inner_type
+        )
+    }
+}
+
+impl CastToFixedSizeListExpr {
+    pub fn new(source: Arc<dyn PhysicalExpr>, dimension: i32, inner_type: DataType) -> Self {
+        Self {
+            source,
+            dimension,
+            inner_type,
+        }
+    }
+
+    pub fn try_new_from_target_type(
+        source: Arc<dyn PhysicalExpr>,
+        target: &DataType,
+    ) -> crate::Result<Self> {
+        match target {
+            DataType::FixedSizeList(inner, dim) => {
+                Ok(Self::new(source, *dim, inner.data_type().clone()))
+            }
+            _ => Err(crate::Error::InvalidInput {
+                message: format!("expected FixedSizeList target type, got {:?}", target),
+            }),
+        }
+    }
+
+    fn cast_fsl(&self, fsl: &FixedSizeListArray) -> datafusion_common::Result<ArrayRef> {
+        if fsl.value_length() != self.dimension {
+            return Err(datafusion_common::DataFusionError::Execution(format!(
+                "FSL dimension mismatch: expected {}, got {}",
+                self.dimension,
+                fsl.value_length()
+            )));
+        }
+        let values = fsl.values();
+        if *values.data_type() == self.inner_type {
+            return Ok(Arc::new(fsl.clone()));
+        }
+        let cast_values = cast(values, &self.inner_type)?;
+        let field = Arc::new(Field::new("item", self.inner_type.clone(), true));
+        let new_fsl =
+            FixedSizeListArray::new(field, self.dimension, cast_values, fsl.nulls().cloned());
+        Ok(Arc::new(new_fsl))
+    }
+}
+
+impl PhysicalExpr for CastToFixedSizeListExpr {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn data_type(&self, _input_schema: &Schema) -> DFResult<DataType> {
+        Ok(DataType::FixedSizeList(
+            Arc::new(Field::new("item", self.inner_type.clone(), true)),
+            self.dimension,
+        ))
+    }
+
+    fn nullable(&self, _input_schema: &Schema) -> DFResult<bool> {
+        Ok(true)
+    }
+
+    fn evaluate(&self, batch: &arrow_array::RecordBatch) -> DFResult<ColumnarValue> {
+        let source_value = self.source.evaluate(batch)?;
+        let array = source_value.into_array(batch.num_rows())?;
+
+        let result = match array.data_type() {
+            DataType::List(_) | DataType::LargeList(_) => {
+                let (offsets, flat_values) = get_list_offsets_and_values(array.as_ref())
+                    .map_err(|e| datafusion_common::DataFusionError::External(e.into()))?;
+                let cast_values = cast(&flat_values, &self.inner_type)?;
+
+                match &self.inner_type {
+                    DataType::Float32 => {
+                        let typed = cast_values.as_primitive::<arrow_array::types::Float32Type>();
+                        build_fsl_from_offsets::<arrow_array::builder::Float32Builder>(
+                            array.as_ref(),
+                            &offsets,
+                            typed,
+                            self.dimension as i64,
+                            &BadVectorStrategy::Null,
+                        )
+                        .map_err(|e| datafusion_common::DataFusionError::External(e.into()))?
+                    }
+                    DataType::UInt8 => {
+                        let typed = cast_values
+                            .as_any()
+                            .downcast_ref::<arrow_array::UInt8Array>()
+                            .expect("cast to UInt8 should succeed");
+                        build_fsl_from_offsets::<arrow_array::builder::UInt8Builder>(
+                            array.as_ref(),
+                            &offsets,
+                            typed,
+                            self.dimension as i64,
+                            &BadVectorStrategy::Null,
+                        )
+                        .map_err(|e| datafusion_common::DataFusionError::External(e.into()))?
+                    }
+                    _ => {
+                        return Err(datafusion_common::DataFusionError::Execution(format!(
+                            "unsupported inner type for FSL cast: {:?}",
+                            self.inner_type
+                        )));
+                    }
+                }
+            }
+            DataType::FixedSizeList(..) => self.cast_fsl(array.as_fixed_size_list())?,
+            other => {
+                return Err(datafusion_common::DataFusionError::Execution(format!(
+                    "CastToFixedSizeListExpr: unsupported source type {:?}",
+                    other
+                )));
+            }
+        };
+
+        // NaN defense-in-depth: nullify rows with NaN
+        let fsl = result.as_fixed_size_list();
+        let is_float = matches!(
+            fsl.value_type(),
+            DataType::Float16 | DataType::Float32 | DataType::Float64
+        );
+        let result = if is_float {
+            let mask = nan_row_mask(fsl);
+            let has_nan = mask.iter().any(|v| v == Some(true));
+            if has_nan {
+                nullify_fsl_rows(fsl, &mask)
+                    .map_err(|e| datafusion_common::DataFusionError::External(e.into()))?
+            } else {
+                result
+            }
+        } else {
+            result
+        };
+
+        Ok(ColumnarValue::Array(result))
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn PhysicalExpr>> {
+        vec![&self.source]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn PhysicalExpr>>,
+    ) -> DFResult<Arc<dyn PhysicalExpr>> {
+        Ok(Arc::new(Self::new(
+            children[0].clone(),
+            self.dimension,
+            self.inner_type.clone(),
+        )))
+    }
+
+    fn fmt_sql(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Ok(())
+    }
+}
+
+fn schemas_equal(a: &Schema, b: &Schema) -> bool {
+    if a.fields().len() != b.fields().len() {
+        return false;
+    }
+    a.fields()
+        .iter()
+        .zip(b.fields().iter())
+        .all(|(af, bf)| af.name() == bf.name() && af.data_type() == bf.data_type())
+}
+
+fn needs_fsl_conversion(source_type: &DataType, target_type: &DataType) -> bool {
+    matches!(target_type, DataType::FixedSizeList(..))
+        && matches!(
+            source_type,
+            DataType::List(_) | DataType::LargeList(_) | DataType::FixedSizeList(..)
+        )
+        && source_type != target_type
+}
+
+/// Builds a [`ProjectionExec`] adapting input schema to target schema.
+///
+/// For each target field, finds the corresponding source field by name and
+/// applies the appropriate cast: `CastToFixedSizeListExpr` for list-to-FSL
+/// conversions, standard `CastExpr` for other type mismatches, or a simple
+/// column passthrough if types already match.
+///
+/// Returns the input unchanged if schemas already match.
+pub fn create_schema_cast_projection(
+    input: Arc<dyn ExecutionPlan>,
+    target_schema: &SchemaRef,
+) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+    let input_schema = input.schema();
+    if schemas_equal(&input_schema, target_schema) {
+        return Ok(input);
+    }
+
+    let mut projections: Vec<(Arc<dyn PhysicalExpr>, String)> = Vec::new();
+
+    for target_field in target_schema.fields() {
+        let name = target_field.name();
+        let source_idx = input_schema.index_of(name)?;
+        let source_field = input_schema.field(source_idx);
+        let col_expr: Arc<dyn PhysicalExpr> = Arc::new(Column::new(name, source_idx));
+
+        if source_field.data_type() == target_field.data_type() {
+            projections.push((col_expr, name.clone()));
+        } else if needs_fsl_conversion(source_field.data_type(), target_field.data_type()) {
+            let cast_expr = CastToFixedSizeListExpr::try_new_from_target_type(
+                col_expr,
+                target_field.data_type(),
+            )
+            .map_err(|e| datafusion_common::DataFusionError::External(e.into()))?;
+            projections.push((Arc::new(cast_expr), name.clone()));
+        } else {
+            let cast_expr = CastExpr::new(col_expr, target_field.data_type().clone(), None);
+            projections.push((Arc::new(cast_expr), name.clone()));
+        }
+    }
+
+    Ok(Arc::new(ProjectionExec::try_new(projections, input)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_array::builder::{
+        FixedSizeListBuilder, Float32Builder, Float64Builder, LargeListBuilder, ListBuilder,
+    };
+    use arrow_array::types::Float32Type;
+    use arrow_array::{Float32Array, RecordBatch};
+    use arrow_schema::Field;
+    use datafusion::prelude::SessionContext;
+    use datafusion_catalog::MemTable;
+    use datafusion_physical_plan::collect;
+
+    fn make_list_f32(values: &[Option<Vec<f32>>]) -> ArrayRef {
+        let mut builder = ListBuilder::new(Float32Builder::new());
+        for row in values {
+            match row {
+                Some(vals) => {
+                    for v in vals {
+                        builder.values().append_value(*v);
+                    }
+                    builder.append(true);
+                }
+                None => {
+                    builder.append(false);
+                }
+            }
+        }
+        Arc::new(builder.finish())
+    }
+
+    fn make_list_f64(values: &[Option<Vec<f64>>]) -> ArrayRef {
+        let mut builder = ListBuilder::new(Float64Builder::new());
+        for row in values {
+            match row {
+                Some(vals) => {
+                    for v in vals {
+                        builder.values().append_value(*v);
+                    }
+                    builder.append(true);
+                }
+                None => {
+                    builder.append(false);
+                }
+            }
+        }
+        Arc::new(builder.finish())
+    }
+
+    fn make_large_list_f32(values: &[Option<Vec<f32>>]) -> ArrayRef {
+        let mut builder = LargeListBuilder::new(Float32Builder::new());
+        for row in values {
+            match row {
+                Some(vals) => {
+                    for v in vals {
+                        builder.values().append_value(*v);
+                    }
+                    builder.append(true);
+                }
+                None => {
+                    builder.append(false);
+                }
+            }
+        }
+        Arc::new(builder.finish())
+    }
+
+    fn make_fsl_f64(values: &[Option<Vec<f64>>], dim: i32) -> ArrayRef {
+        let dim_usize = dim as usize;
+        let n = values.len();
+        let mut builder =
+            FixedSizeListBuilder::new(Float64Builder::with_capacity(n * dim_usize), dim);
+        for row in values {
+            match row {
+                Some(vals) => {
+                    for v in vals {
+                        builder.values().append_value(*v);
+                    }
+                    builder.append(true);
+                }
+                None => {
+                    for _ in 0..dim_usize {
+                        builder.values().append_null();
+                    }
+                    builder.append(false);
+                }
+            }
+        }
+        Arc::new(builder.finish())
+    }
+
+    fn eval_expr(expr: &CastToFixedSizeListExpr, batch: &RecordBatch) -> ArrayRef {
+        match expr.evaluate(batch).unwrap() {
+            ColumnarValue::Array(a) => a,
+            _ => panic!("expected array"),
+        }
+    }
+
+    fn source_col() -> Arc<dyn PhysicalExpr> {
+        Arc::new(Column::new("vec", 0))
+    }
+
+    #[test]
+    fn test_list_f32_to_fsl() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "vec",
+            DataType::List(Arc::new(Field::new("item", DataType::Float32, true))),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![make_list_f32(&[
+                Some(vec![1.0, 2.0, 3.0]),
+                Some(vec![4.0, 5.0, 6.0]),
+            ])],
+        )
+        .unwrap();
+
+        let expr = CastToFixedSizeListExpr::new(source_col(), 3, DataType::Float32);
+        let result = eval_expr(&expr, &batch);
+        let fsl = result.as_fixed_size_list();
+        assert_eq!(fsl.len(), 2);
+        assert_eq!(fsl.value_length(), 3);
+        let row0 = fsl.value(0);
+        let vals = row0.as_primitive::<Float32Type>();
+        assert_eq!(vals.value(0), 1.0);
+        assert_eq!(vals.value(1), 2.0);
+        assert_eq!(vals.value(2), 3.0);
+    }
+
+    #[test]
+    fn test_list_f64_to_fsl_f32() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "vec",
+            DataType::List(Arc::new(Field::new("item", DataType::Float64, true))),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![make_list_f64(&[Some(vec![1.0, 2.0]), Some(vec![3.0, 4.0])])],
+        )
+        .unwrap();
+
+        let expr = CastToFixedSizeListExpr::new(source_col(), 2, DataType::Float32);
+        let result = eval_expr(&expr, &batch);
+        let fsl = result.as_fixed_size_list();
+        assert_eq!(fsl.len(), 2);
+        assert_eq!(fsl.value_type(), DataType::Float32);
+        let row0 = fsl.value(0);
+        let vals = row0.as_primitive::<Float32Type>();
+        assert_eq!(vals.value(0), 1.0);
+        assert_eq!(vals.value(1), 2.0);
+    }
+
+    #[test]
+    fn test_large_list_to_fsl() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "vec",
+            DataType::LargeList(Arc::new(Field::new("item", DataType::Float32, true))),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![make_large_list_f32(&[
+                Some(vec![1.0, 2.0]),
+                Some(vec![3.0, 4.0]),
+            ])],
+        )
+        .unwrap();
+
+        let expr = CastToFixedSizeListExpr::new(source_col(), 2, DataType::Float32);
+        let result = eval_expr(&expr, &batch);
+        let fsl = result.as_fixed_size_list();
+        assert_eq!(fsl.len(), 2);
+        assert_eq!(fsl.value_length(), 2);
+    }
+
+    #[test]
+    fn test_fsl_to_fsl_cast_inner() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "vec",
+            DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float64, true)), 3),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![make_fsl_f64(
+                &[Some(vec![1.0, 2.0, 3.0]), Some(vec![4.0, 5.0, 6.0])],
+                3,
+            )],
+        )
+        .unwrap();
+
+        let expr = CastToFixedSizeListExpr::new(source_col(), 3, DataType::Float32);
+        let result = eval_expr(&expr, &batch);
+        let fsl = result.as_fixed_size_list();
+        assert_eq!(fsl.value_type(), DataType::Float32);
+        let row0 = fsl.value(0);
+        let vals = row0.as_primitive::<Float32Type>();
+        assert_eq!(vals.value(0), 1.0);
+    }
+
+    #[test]
+    fn test_wrong_dim_becomes_null() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "vec",
+            DataType::List(Arc::new(Field::new("item", DataType::Float32, true))),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![make_list_f32(&[
+                Some(vec![1.0, 2.0, 3.0]),
+                Some(vec![4.0, 5.0]), // wrong dim
+                Some(vec![7.0, 8.0, 9.0]),
+            ])],
+        )
+        .unwrap();
+
+        let expr = CastToFixedSizeListExpr::new(source_col(), 3, DataType::Float32);
+        let result = eval_expr(&expr, &batch);
+        let fsl = result.as_fixed_size_list();
+        assert!(!fsl.is_null(0));
+        assert!(fsl.is_null(1)); // wrong dim → null
+        assert!(!fsl.is_null(2));
+    }
+
+    #[test]
+    fn test_nan_rows_become_null() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "vec",
+            DataType::List(Arc::new(Field::new("item", DataType::Float32, true))),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![make_list_f32(&[
+                Some(vec![1.0, 2.0, 3.0]),
+                Some(vec![f32::NAN, 5.0, 6.0]),
+                Some(vec![7.0, 8.0, 9.0]),
+            ])],
+        )
+        .unwrap();
+
+        let expr = CastToFixedSizeListExpr::new(source_col(), 3, DataType::Float32);
+        let result = eval_expr(&expr, &batch);
+        let fsl = result.as_fixed_size_list();
+        assert!(!fsl.is_null(0));
+        assert!(fsl.is_null(1)); // NaN → null
+        assert!(!fsl.is_null(2));
+    }
+
+    #[test]
+    fn test_null_rows_preserved() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "vec",
+            DataType::List(Arc::new(Field::new("item", DataType::Float32, true))),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![make_list_f32(&[
+                Some(vec![1.0, 2.0, 3.0]),
+                None,
+                Some(vec![7.0, 8.0, 9.0]),
+            ])],
+        )
+        .unwrap();
+
+        let expr = CastToFixedSizeListExpr::new(source_col(), 3, DataType::Float32);
+        let result = eval_expr(&expr, &batch);
+        let fsl = result.as_fixed_size_list();
+        assert!(!fsl.is_null(0));
+        assert!(fsl.is_null(1)); // was null, stays null
+        assert!(!fsl.is_null(2));
+    }
+
+    #[tokio::test]
+    async fn test_schema_cast_projection_noop() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Float32, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(arrow_array::Int32Array::from(vec![1, 2])),
+                Arc::new(Float32Array::from(vec![1.0, 2.0])),
+            ],
+        )
+        .unwrap();
+
+        let mem_table = MemTable::try_new(schema.clone(), vec![vec![batch]]).unwrap();
+        let ctx = SessionContext::new();
+        ctx.register_table("t", Arc::new(mem_table)).unwrap();
+        let df = ctx.sql("SELECT * FROM t").await.unwrap();
+        let input = df.create_physical_plan().await.unwrap();
+
+        let result = create_schema_cast_projection(input.clone(), &schema).unwrap();
+        // Should return input unchanged (same Arc)
+        assert!(Arc::ptr_eq(&result, &input));
+    }
+
+    #[tokio::test]
+    async fn test_schema_cast_projection_vector_cast() {
+        let source_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new(
+                "vec",
+                DataType::List(Arc::new(Field::new("item", DataType::Float32, true))),
+                true,
+            ),
+        ]));
+        let target_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new(
+                "vec",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), 3),
+                true,
+            ),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            source_schema.clone(),
+            vec![
+                Arc::new(arrow_array::Int32Array::from(vec![1, 2])),
+                make_list_f32(&[Some(vec![1.0, 2.0, 3.0]), Some(vec![4.0, 5.0, 6.0])]),
+            ],
+        )
+        .unwrap();
+
+        let mem_table = MemTable::try_new(source_schema.clone(), vec![vec![batch]]).unwrap();
+        let ctx = SessionContext::new();
+        ctx.register_table("t", Arc::new(mem_table)).unwrap();
+        let df = ctx.sql("SELECT * FROM t").await.unwrap();
+        let input = df.create_physical_plan().await.unwrap();
+
+        let result_plan = create_schema_cast_projection(input, &target_schema).unwrap();
+        let batches = collect(result_plan, ctx.task_ctx()).await.unwrap();
+        assert_eq!(batches.len(), 1);
+        let result_batch = &batches[0];
+
+        // Verify the vec column is now FSL
+        let fsl = result_batch.column(1).as_fixed_size_list();
+        assert_eq!(fsl.value_length(), 3);
+        let row0 = fsl.value(0);
+        let vals = row0.as_primitive::<Float32Type>();
+        assert_eq!(vals.value(0), 1.0);
+        assert_eq!(vals.value(1), 2.0);
+        assert_eq!(vals.value(2), 3.0);
+    }
+}

--- a/rust/lancedb/src/table/datafusion/cast_vector.rs
+++ b/rust/lancedb/src/table/datafusion/cast_vector.rs
@@ -100,8 +100,21 @@ impl CastToFixedSizeListExpr {
             )));
         }
         let values = fsl.values();
-        if *values.data_type() == *self.inner_type() {
+        let DataType::FixedSizeList(source_field, _) = fsl.data_type() else {
+            unreachable!()
+        };
+        if source_field == &self.inner_field {
             return Ok(Arc::new(fsl.clone()));
+        }
+        if *values.data_type() == *self.inner_type() {
+            // Types match but field name/nullability differs — rebuild with target field
+            let new_fsl = FixedSizeListArray::new(
+                self.inner_field.clone(),
+                self.dimension,
+                values.clone(),
+                fsl.nulls().cloned(),
+            );
+            return Ok(Arc::new(new_fsl));
         }
         let cast_values = cast(values, self.inner_type())?;
         let new_fsl = FixedSizeListArray::new(
@@ -178,8 +191,8 @@ impl PhysicalExpr for CastToFixedSizeListExpr {
                         )
                         .map_err(|e| datafusion_common::DataFusionError::External(e.into()))?
                     }
-                    _ => {
-                        // Fallback: build as Float32, then cast inner values to target type
+                    DataType::Float16 => {
+                        // Float16 is a subset of Float32, so build via Float32 then cast
                         let f32_values = cast(&flat_values, &DataType::Float32)?;
                         let typed = f32_values.as_primitive::<arrow_array::types::Float32Type>();
                         let fsl = build_fsl_from_offsets::<arrow_array::builder::Float32Builder>(
@@ -190,10 +203,15 @@ impl PhysicalExpr for CastToFixedSizeListExpr {
                             &BadVectorStrategy::Null,
                         )
                         .map_err(|e| datafusion_common::DataFusionError::External(e.into()))?;
-                        // Cast the FSL to the target inner type
                         let target_dt =
                             DataType::FixedSizeList(self.inner_field.clone(), self.dimension);
                         cast(&fsl, &target_dt)?
+                    }
+                    _ => {
+                        return Err(datafusion_common::DataFusionError::Execution(format!(
+                            "CastToFixedSizeListExpr: unsupported target inner type {:?}",
+                            inner_type
+                        )));
                     }
                 }
             }
@@ -248,6 +266,9 @@ impl PhysicalExpr for CastToFixedSizeListExpr {
     }
 }
 
+/// Compares schemas by field name, data type, and nullability. Metadata is
+/// intentionally excluded because projections cannot change field metadata —
+/// the output schema comes from the expressions, not the target.
 fn schemas_equal(a: &Schema, b: &Schema) -> bool {
     if a.fields().len() != b.fields().len() {
         return false;
@@ -791,5 +812,107 @@ mod tests {
         assert_eq!(vals.value(0), 1.0);
         assert_eq!(vals.value(1), 2.0);
         assert_eq!(vals.value(2), 3.0);
+    }
+
+    #[test]
+    fn test_fsl_to_fsl_different_field_name() {
+        // Source FSL has inner field "item", target has "values" — should rebuild
+        let source_inner = Arc::new(Field::new("item", DataType::Float32, true));
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "vec",
+            DataType::FixedSizeList(source_inner, 2),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![{
+                let mut builder = FixedSizeListBuilder::new(Float32Builder::with_capacity(4), 2);
+                for vals in &[vec![1.0_f32, 2.0], vec![3.0, 4.0]] {
+                    for v in vals {
+                        builder.values().append_value(*v);
+                    }
+                    builder.append(true);
+                }
+                Arc::new(builder.finish()) as ArrayRef
+            }],
+        )
+        .unwrap();
+
+        let target_inner = Arc::new(Field::new("values", DataType::Float32, true));
+        let target = DataType::FixedSizeList(target_inner, 2);
+        let expr =
+            CastToFixedSizeListExpr::try_new_from_target_type(source_col(), &target).unwrap();
+        let result = eval_expr(&expr, &batch);
+        let fsl = result.as_fixed_size_list();
+        assert_eq!(fsl.len(), 2);
+        // Inner field name should now be "values"
+        match fsl.data_type() {
+            DataType::FixedSizeList(field, _) => assert_eq!(field.name(), "values"),
+            _ => panic!("expected FSL"),
+        }
+        let row0 = fsl.value(0);
+        let vals = row0.as_primitive::<Float32Type>();
+        assert_eq!(vals.value(0), 1.0);
+    }
+
+    #[test]
+    fn test_fsl_to_fsl_different_nullability() {
+        // Source FSL inner is nullable=true, target is nullable=false — should rebuild
+        let source_inner = Arc::new(Field::new("item", DataType::Float32, true));
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "vec",
+            DataType::FixedSizeList(source_inner, 2),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![{
+                let mut builder = FixedSizeListBuilder::new(Float32Builder::with_capacity(4), 2);
+                for vals in &[vec![1.0_f32, 2.0], vec![3.0, 4.0]] {
+                    for v in vals {
+                        builder.values().append_value(*v);
+                    }
+                    builder.append(true);
+                }
+                Arc::new(builder.finish()) as ArrayRef
+            }],
+        )
+        .unwrap();
+
+        let target_inner = Arc::new(Field::new("item", DataType::Float32, false));
+        let target = DataType::FixedSizeList(target_inner, 2);
+        let expr =
+            CastToFixedSizeListExpr::try_new_from_target_type(source_col(), &target).unwrap();
+        let result = eval_expr(&expr, &batch);
+        let fsl = result.as_fixed_size_list();
+        match fsl.data_type() {
+            DataType::FixedSizeList(field, _) => assert!(!field.is_nullable()),
+            _ => panic!("expected FSL"),
+        }
+    }
+
+    #[test]
+    fn test_unsupported_target_type_errors() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "vec",
+            DataType::List(Arc::new(Field::new("item", DataType::Float32, true))),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![make_list_f32(&[Some(vec![1.0, 2.0]), Some(vec![3.0, 4.0])])],
+        )
+        .unwrap();
+
+        // Int64 is not a supported vector inner type
+        let expr = CastToFixedSizeListExpr::new(source_col(), 2, DataType::Int64);
+        let result = expr.evaluate(&batch);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("unsupported target inner type"),
+            "error should mention unsupported type: {}",
+            err
+        );
     }
 }

--- a/rust/lancedb/src/table/datafusion/cast_vector.rs
+++ b/rust/lancedb/src/table/datafusion/cast_vector.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use arrow_array::cast::AsArray;
 use arrow_array::{Array, ArrayRef, FixedSizeListArray};
 use arrow_cast::cast;
-use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use arrow_schema::{DataType, Field, FieldRef, Schema, SchemaRef};
 use datafusion_common::Result as DataFusionResult;
 
 type DFResult<T> = DataFusionResult<T>;
@@ -31,14 +31,14 @@ use crate::data::preprocessing::{
 pub struct CastToFixedSizeListExpr {
     source: Arc<dyn PhysicalExpr>,
     dimension: i32,
-    inner_type: DataType,
+    inner_field: FieldRef,
 }
 
 impl PartialEq for CastToFixedSizeListExpr {
     fn eq(&self, other: &Self) -> bool {
         self.source.eq(&other.source)
             && self.dimension == other.dimension
-            && self.inner_type == other.inner_type
+            && self.inner_field == other.inner_field
     }
 }
 
@@ -46,7 +46,7 @@ impl Hash for CastToFixedSizeListExpr {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.source.hash(state);
         self.dimension.hash(state);
-        self.inner_type.hash(state);
+        self.inner_field.hash(state);
     }
 }
 
@@ -55,7 +55,9 @@ impl fmt::Display for CastToFixedSizeListExpr {
         write!(
             f,
             "CastToFSL({}, dim={}, inner={})",
-            self.source, self.dimension, self.inner_type
+            self.source,
+            self.dimension,
+            self.inner_field.data_type()
         )
     }
 }
@@ -65,7 +67,7 @@ impl CastToFixedSizeListExpr {
         Self {
             source,
             dimension,
-            inner_type,
+            inner_field: Arc::new(Field::new("item", inner_type, true)),
         }
     }
 
@@ -74,13 +76,19 @@ impl CastToFixedSizeListExpr {
         target: &DataType,
     ) -> crate::Result<Self> {
         match target {
-            DataType::FixedSizeList(inner, dim) => {
-                Ok(Self::new(source, *dim, inner.data_type().clone()))
-            }
+            DataType::FixedSizeList(inner, dim) => Ok(Self {
+                source,
+                dimension: *dim,
+                inner_field: inner.clone(),
+            }),
             _ => Err(crate::Error::InvalidInput {
                 message: format!("expected FixedSizeList target type, got {:?}", target),
             }),
         }
+    }
+
+    fn inner_type(&self) -> &DataType {
+        self.inner_field.data_type()
     }
 
     fn cast_fsl(&self, fsl: &FixedSizeListArray) -> datafusion_common::Result<ArrayRef> {
@@ -92,13 +100,16 @@ impl CastToFixedSizeListExpr {
             )));
         }
         let values = fsl.values();
-        if *values.data_type() == self.inner_type {
+        if *values.data_type() == *self.inner_type() {
             return Ok(Arc::new(fsl.clone()));
         }
-        let cast_values = cast(values, &self.inner_type)?;
-        let field = Arc::new(Field::new("item", self.inner_type.clone(), true));
-        let new_fsl =
-            FixedSizeListArray::new(field, self.dimension, cast_values, fsl.nulls().cloned());
+        let cast_values = cast(values, self.inner_type())?;
+        let new_fsl = FixedSizeListArray::new(
+            self.inner_field.clone(),
+            self.dimension,
+            cast_values,
+            fsl.nulls().cloned(),
+        );
         Ok(Arc::new(new_fsl))
     }
 }
@@ -110,7 +121,7 @@ impl PhysicalExpr for CastToFixedSizeListExpr {
 
     fn data_type(&self, _input_schema: &Schema) -> DFResult<DataType> {
         Ok(DataType::FixedSizeList(
-            Arc::new(Field::new("item", self.inner_type.clone(), true)),
+            self.inner_field.clone(),
             self.dimension,
         ))
     }
@@ -122,17 +133,29 @@ impl PhysicalExpr for CastToFixedSizeListExpr {
     fn evaluate(&self, batch: &arrow_array::RecordBatch) -> DFResult<ColumnarValue> {
         let source_value = self.source.evaluate(batch)?;
         let array = source_value.into_array(batch.num_rows())?;
+        let inner_type = self.inner_type();
 
         let result = match array.data_type() {
             DataType::List(_) | DataType::LargeList(_) => {
                 let (offsets, flat_values) = get_list_offsets_and_values(array.as_ref())
                     .map_err(|e| datafusion_common::DataFusionError::External(e.into()))?;
-                let cast_values = cast(&flat_values, &self.inner_type)?;
+                let cast_values = cast(&flat_values, inner_type)?;
 
-                match &self.inner_type {
+                match inner_type {
                     DataType::Float32 => {
                         let typed = cast_values.as_primitive::<arrow_array::types::Float32Type>();
                         build_fsl_from_offsets::<arrow_array::builder::Float32Builder>(
+                            array.as_ref(),
+                            &offsets,
+                            typed,
+                            self.dimension as i64,
+                            &BadVectorStrategy::Null,
+                        )
+                        .map_err(|e| datafusion_common::DataFusionError::External(e.into()))?
+                    }
+                    DataType::Float64 => {
+                        let typed = cast_values.as_primitive::<arrow_array::types::Float64Type>();
+                        build_fsl_from_offsets::<arrow_array::builder::Float64Builder>(
                             array.as_ref(),
                             &offsets,
                             typed,
@@ -156,10 +179,21 @@ impl PhysicalExpr for CastToFixedSizeListExpr {
                         .map_err(|e| datafusion_common::DataFusionError::External(e.into()))?
                     }
                     _ => {
-                        return Err(datafusion_common::DataFusionError::Execution(format!(
-                            "unsupported inner type for FSL cast: {:?}",
-                            self.inner_type
-                        )));
+                        // Fallback: build as Float32, then cast inner values to target type
+                        let f32_values = cast(&flat_values, &DataType::Float32)?;
+                        let typed = f32_values.as_primitive::<arrow_array::types::Float32Type>();
+                        let fsl = build_fsl_from_offsets::<arrow_array::builder::Float32Builder>(
+                            array.as_ref(),
+                            &offsets,
+                            typed,
+                            self.dimension as i64,
+                            &BadVectorStrategy::Null,
+                        )
+                        .map_err(|e| datafusion_common::DataFusionError::External(e.into()))?;
+                        // Cast the FSL to the target inner type
+                        let target_dt =
+                            DataType::FixedSizeList(self.inner_field.clone(), self.dimension);
+                        cast(&fsl, &target_dt)?
                     }
                 }
             }
@@ -202,11 +236,11 @@ impl PhysicalExpr for CastToFixedSizeListExpr {
         self: Arc<Self>,
         children: Vec<Arc<dyn PhysicalExpr>>,
     ) -> DFResult<Arc<dyn PhysicalExpr>> {
-        Ok(Arc::new(Self::new(
-            children[0].clone(),
-            self.dimension,
-            self.inner_type.clone(),
-        )))
+        Ok(Arc::new(Self {
+            source: children[0].clone(),
+            dimension: self.dimension,
+            inner_field: self.inner_field.clone(),
+        }))
     }
 
     fn fmt_sql(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -218,10 +252,11 @@ fn schemas_equal(a: &Schema, b: &Schema) -> bool {
     if a.fields().len() != b.fields().len() {
         return false;
     }
-    a.fields()
-        .iter()
-        .zip(b.fields().iter())
-        .all(|(af, bf)| af.name() == bf.name() && af.data_type() == bf.data_type())
+    a.fields().iter().zip(b.fields().iter()).all(|(af, bf)| {
+        af.name() == bf.name()
+            && af.data_type() == bf.data_type()
+            && af.is_nullable() == bf.is_nullable()
+    })
 }
 
 fn needs_fsl_conversion(source_type: &DataType, target_type: &DataType) -> bool {
@@ -258,7 +293,9 @@ pub fn create_schema_cast_projection(
         let source_field = input_schema.field(source_idx);
         let col_expr: Arc<dyn PhysicalExpr> = Arc::new(Column::new(name, source_idx));
 
-        if source_field.data_type() == target_field.data_type() {
+        if source_field.data_type() == target_field.data_type()
+            && source_field.is_nullable() == target_field.is_nullable()
+        {
             projections.push((col_expr, name.clone()));
         } else if needs_fsl_conversion(source_field.data_type(), target_field.data_type()) {
             let cast_expr = CastToFixedSizeListExpr::try_new_from_target_type(
@@ -577,6 +614,134 @@ mod tests {
         let result = create_schema_cast_projection(input.clone(), &schema).unwrap();
         // Should return input unchanged (same Arc)
         assert!(Arc::ptr_eq(&result, &input));
+    }
+
+    #[test]
+    fn test_list_f64_to_fsl_f64() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "vec",
+            DataType::List(Arc::new(Field::new("item", DataType::Float64, true))),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![make_list_f64(&[Some(vec![1.0, 2.0]), Some(vec![3.0, 4.0])])],
+        )
+        .unwrap();
+
+        let expr = CastToFixedSizeListExpr::new(source_col(), 2, DataType::Float64);
+        let result = eval_expr(&expr, &batch);
+        let fsl = result.as_fixed_size_list();
+        assert_eq!(fsl.len(), 2);
+        assert_eq!(fsl.value_type(), DataType::Float64);
+        let row0 = fsl.value(0);
+        let vals = row0.as_primitive::<arrow_array::types::Float64Type>();
+        assert_eq!(vals.value(0), 1.0);
+        assert_eq!(vals.value(1), 2.0);
+    }
+
+    #[test]
+    fn test_list_f32_to_fsl_u8() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "vec",
+            DataType::List(Arc::new(Field::new("item", DataType::Float32, true))),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![make_list_f32(&[
+                Some(vec![1.0, 2.0, 3.0]),
+                Some(vec![100.0, 200.0, 255.0]),
+            ])],
+        )
+        .unwrap();
+
+        let expr = CastToFixedSizeListExpr::new(source_col(), 3, DataType::UInt8);
+        let result = eval_expr(&expr, &batch);
+        let fsl = result.as_fixed_size_list();
+        assert_eq!(fsl.len(), 2);
+        assert_eq!(fsl.value_type(), DataType::UInt8);
+    }
+
+    #[test]
+    fn test_large_list_to_fsl_f64() {
+        let mut builder = LargeListBuilder::new(Float64Builder::new());
+        for vals in &[vec![1.0_f64, 2.0], vec![3.0, 4.0]] {
+            for v in vals {
+                builder.values().append_value(*v);
+            }
+            builder.append(true);
+        }
+        let arr: ArrayRef = Arc::new(builder.finish());
+
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "vec",
+            DataType::LargeList(Arc::new(Field::new("item", DataType::Float64, true))),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(schema, vec![arr]).unwrap();
+
+        let expr = CastToFixedSizeListExpr::new(source_col(), 2, DataType::Float64);
+        let result = eval_expr(&expr, &batch);
+        let fsl = result.as_fixed_size_list();
+        assert_eq!(fsl.len(), 2);
+        assert_eq!(fsl.value_type(), DataType::Float64);
+    }
+
+    #[test]
+    fn test_try_new_from_target_preserves_inner_field() {
+        let inner = Arc::new(Field::new("values", DataType::Float64, false));
+        let target = DataType::FixedSizeList(inner.clone(), 4);
+        let expr =
+            CastToFixedSizeListExpr::try_new_from_target_type(source_col(), &target).unwrap();
+        let schema = Schema::new(vec![Field::new(
+            "vec",
+            DataType::List(Arc::new(Field::new("item", DataType::Float64, true))),
+            true,
+        )]);
+        let dt = expr.data_type(&schema).unwrap();
+        match dt {
+            DataType::FixedSizeList(field, dim) => {
+                assert_eq!(dim, 4);
+                assert_eq!(field.name(), "values");
+                assert_eq!(field.data_type(), &DataType::Float64);
+                assert!(!field.is_nullable());
+            }
+            _ => panic!("expected FixedSizeList"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_schema_cast_projection_nullability_diff() {
+        // Source has nullable=true, target has nullable=false for a column.
+        // schemas_equal should detect this and create a projection.
+        let source_schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, true),
+            Field::new("b", DataType::Float32, true),
+        ]));
+        let target_schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Float32, true),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            source_schema.clone(),
+            vec![
+                Arc::new(arrow_array::Int32Array::from(vec![1, 2])),
+                Arc::new(Float32Array::from(vec![1.0, 2.0])),
+            ],
+        )
+        .unwrap();
+
+        let mem_table = MemTable::try_new(source_schema, vec![vec![batch]]).unwrap();
+        let ctx = SessionContext::new();
+        ctx.register_table("t", Arc::new(mem_table)).unwrap();
+        let df = ctx.sql("SELECT * FROM t").await.unwrap();
+        let input = df.create_physical_plan().await.unwrap();
+
+        let result = create_schema_cast_projection(input.clone(), &target_schema).unwrap();
+        // Should NOT return the same input since nullability differs
+        assert!(!Arc::ptr_eq(&result, &input));
     }
 
     #[tokio::test]

--- a/rust/lancedb/src/table/datafusion/embedding_udf.rs
+++ b/rust/lancedb/src/table/datafusion/embedding_udf.rs
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
+//! DataFusion physical expression and projection for computing embeddings.
+
+use std::any::Any;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+use arrow_array::ArrayRef;
+use arrow_schema::{DataType, Field, Schema};
+use datafusion_common::{DataFusionError, Result as DFResult};
+use datafusion_expr::ColumnarValue;
+use datafusion_physical_expr::expressions::Column;
+use datafusion_physical_expr::PhysicalExpr;
+use datafusion_physical_plan::projection::ProjectionExec;
+use datafusion_physical_plan::ExecutionPlan;
+
+use crate::embeddings::{EmbeddingDefinition, EmbeddingFunction};
+
+/// Wraps an [`EmbeddingFunction`] as a DataFusion physical expression.
+#[derive(Debug)]
+pub struct EmbeddingPhysicalExpr {
+    source_expr: Arc<dyn PhysicalExpr>,
+    embedding_function: Arc<dyn EmbeddingFunction>,
+    return_type: DataType,
+}
+
+impl PartialEq for EmbeddingPhysicalExpr {
+    fn eq(&self, other: &Self) -> bool {
+        self.source_expr.eq(&other.source_expr)
+            && Arc::ptr_eq(&self.embedding_function, &other.embedding_function)
+            && self.return_type == other.return_type
+    }
+}
+
+impl Eq for EmbeddingPhysicalExpr {}
+
+impl Hash for EmbeddingPhysicalExpr {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.source_expr.hash(state);
+        (Arc::as_ptr(&self.embedding_function) as *const () as usize).hash(state);
+        self.return_type.hash(state);
+    }
+}
+
+impl fmt::Display for EmbeddingPhysicalExpr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Embedding({}, func={})",
+            self.source_expr,
+            self.embedding_function.name()
+        )
+    }
+}
+
+impl EmbeddingPhysicalExpr {
+    pub fn new(
+        source_expr: Arc<dyn PhysicalExpr>,
+        embedding_function: Arc<dyn EmbeddingFunction>,
+    ) -> crate::Result<Self> {
+        let raw_type = embedding_function.dest_type()?.into_owned();
+        // Normalize FSL inner field to nullable to match DataFusion schema conventions
+        let return_type = match raw_type {
+            DataType::FixedSizeList(inner, dim) => DataType::FixedSizeList(
+                Arc::new(Field::new(inner.name(), inner.data_type().clone(), true)),
+                dim,
+            ),
+            other => other,
+        };
+        Ok(Self {
+            source_expr,
+            embedding_function,
+            return_type,
+        })
+    }
+}
+
+impl PhysicalExpr for EmbeddingPhysicalExpr {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn data_type(&self, _input_schema: &Schema) -> DFResult<DataType> {
+        Ok(self.return_type.clone())
+    }
+
+    fn nullable(&self, _input_schema: &Schema) -> DFResult<bool> {
+        Ok(true)
+    }
+
+    fn evaluate(&self, batch: &arrow_array::RecordBatch) -> DFResult<ColumnarValue> {
+        let source_value = self.source_expr.evaluate(batch)?;
+        let array: ArrayRef = source_value.into_array(batch.num_rows())?;
+        let result = self
+            .embedding_function
+            .compute_source_embeddings(array)
+            .map_err(|e| DataFusionError::External(e.into()))?;
+        // Ensure the result array matches the schema type from data_type().
+        // DataFusion's ProjectionExec may normalize inner field nullability,
+        // so we cast if needed to avoid schema mismatches.
+        let result = arrow_cast::cast(&result, &self.return_type)?;
+        Ok(ColumnarValue::Array(result))
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn PhysicalExpr>> {
+        vec![&self.source_expr]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn PhysicalExpr>>,
+    ) -> DFResult<Arc<dyn PhysicalExpr>> {
+        Ok(Arc::new(Self {
+            source_expr: children[0].clone(),
+            embedding_function: self.embedding_function.clone(),
+            return_type: self.return_type.clone(),
+        }))
+    }
+
+    fn fmt_sql(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Ok(())
+    }
+}
+
+/// Builds a [`ProjectionExec`] that appends embedding columns to the input.
+///
+/// For each embedding definition, creates an [`EmbeddingPhysicalExpr`] that
+/// computes the embedding from the source column and adds it as a new column.
+/// If the destination column already exists in the input schema, it is skipped.
+///
+/// Returns the input unchanged if `embeddings` is empty or no new columns are needed.
+pub fn build_embedding_projection(
+    input: Arc<dyn ExecutionPlan>,
+    embeddings: &[(EmbeddingDefinition, Arc<dyn EmbeddingFunction>)],
+) -> DFResult<Arc<dyn ExecutionPlan>> {
+    if embeddings.is_empty() {
+        return Ok(input);
+    }
+
+    let input_schema = input.schema();
+
+    // Start with passthrough for all existing columns
+    let mut projections: Vec<(Arc<dyn PhysicalExpr>, String)> = input_schema
+        .fields()
+        .iter()
+        .enumerate()
+        .map(|(i, f)| {
+            let expr: Arc<dyn PhysicalExpr> = Arc::new(Column::new(f.name(), i));
+            (expr, f.name().clone())
+        })
+        .collect();
+
+    let mut added = false;
+    for (def, func) in embeddings {
+        let dest_name = def
+            .dest_column
+            .clone()
+            .unwrap_or_else(|| format!("{}_embedding", def.source_column));
+
+        if input_schema.field_with_name(&dest_name).is_ok() {
+            continue;
+        }
+
+        let source_idx = input_schema.index_of(&def.source_column)?;
+        let source_expr: Arc<dyn PhysicalExpr> =
+            Arc::new(Column::new(&def.source_column, source_idx));
+        let embed_expr = EmbeddingPhysicalExpr::new(source_expr, func.clone())
+            .map_err(|e| DataFusionError::External(e.into()))?;
+        projections.push((Arc::new(embed_expr), dest_name));
+        added = true;
+    }
+
+    if !added {
+        return Ok(input);
+    }
+
+    Ok(Arc::new(ProjectionExec::try_new(projections, input)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_array::cast::AsArray;
+    use arrow_array::{Array, RecordBatch, StringArray};
+    use arrow_schema::{Field, Schema};
+    use datafusion::prelude::SessionContext;
+    use datafusion_catalog::MemTable;
+    use datafusion_physical_plan::collect;
+
+    use crate::test_utils::embeddings::MockEmbed;
+
+    fn make_text_batch() -> (Arc<Schema>, RecordBatch) {
+        let schema = Arc::new(Schema::new(vec![Field::new("text", DataType::Utf8, false)]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(StringArray::from(vec!["hello", "world"]))],
+        )
+        .unwrap();
+        (schema, batch)
+    }
+
+    #[test]
+    fn test_embedding_expr_evaluate() {
+        let (_schema, batch) = make_text_batch();
+        let mock = Arc::new(MockEmbed::new("test", 4));
+        let source_expr: Arc<dyn PhysicalExpr> = Arc::new(Column::new("text", 0));
+        let expr = EmbeddingPhysicalExpr::new(source_expr, mock).unwrap();
+
+        let result = expr.evaluate(&batch).unwrap();
+        match result {
+            ColumnarValue::Array(arr) => {
+                let fsl = arr.as_fixed_size_list();
+                assert_eq!(fsl.len(), 2);
+                assert_eq!(fsl.value_length(), 4);
+            }
+            _ => panic!("expected array"),
+        }
+    }
+
+    #[test]
+    fn test_embedding_expr_data_type() {
+        let mock = Arc::new(MockEmbed::new("test", 4));
+        let source_expr: Arc<dyn PhysicalExpr> = Arc::new(Column::new("text", 0));
+        let expr = EmbeddingPhysicalExpr::new(source_expr, mock).unwrap();
+
+        let schema = Schema::new(vec![Field::new("text", DataType::Utf8, false)]);
+        let dt = expr.data_type(&schema).unwrap();
+        assert_eq!(
+            dt,
+            DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), 4)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_build_projection_adds_column() {
+        let (schema, batch) = make_text_batch();
+        let mock: Arc<dyn EmbeddingFunction> = Arc::new(MockEmbed::new("test", 4));
+        let def = EmbeddingDefinition::new("text", "test", Some("text_vec"));
+
+        let mem_table = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        let ctx = SessionContext::new();
+        ctx.register_table("t", Arc::new(mem_table)).unwrap();
+        let df = ctx.sql("SELECT * FROM t").await.unwrap();
+        let input = df.create_physical_plan().await.unwrap();
+
+        let result_plan = build_embedding_projection(input, &[(def, mock)]).unwrap();
+        let batches = collect(result_plan, ctx.task_ctx()).await.unwrap();
+        assert_eq!(batches.len(), 1);
+        let result = &batches[0];
+        assert_eq!(result.num_columns(), 2);
+        assert_eq!(result.schema().field(1).name(), "text_vec");
+        let fsl = result.column(1).as_fixed_size_list();
+        assert_eq!(fsl.len(), 2);
+        assert_eq!(fsl.value_length(), 4);
+    }
+
+    #[tokio::test]
+    async fn test_build_projection_skips_existing() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("text", DataType::Utf8, false),
+            Field::new("text_vec", DataType::Float32, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["hello", "world"])),
+                Arc::new(arrow_array::Float32Array::from(vec![1.0, 2.0])),
+            ],
+        )
+        .unwrap();
+
+        let mock: Arc<dyn EmbeddingFunction> = Arc::new(MockEmbed::new("test", 4));
+        let def = EmbeddingDefinition::new("text", "test", Some("text_vec"));
+
+        let mem_table = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        let ctx = SessionContext::new();
+        ctx.register_table("t", Arc::new(mem_table)).unwrap();
+        let df = ctx.sql("SELECT * FROM t").await.unwrap();
+        let input = df.create_physical_plan().await.unwrap();
+
+        let result_plan = build_embedding_projection(input.clone(), &[(def, mock)]).unwrap();
+        // Should return input unchanged since dest column already exists
+        assert!(Arc::ptr_eq(&result_plan, &input));
+    }
+
+    #[tokio::test]
+    async fn test_build_projection_default_name() {
+        let (schema, batch) = make_text_batch();
+        let mock: Arc<dyn EmbeddingFunction> = Arc::new(MockEmbed::new("test", 4));
+        // No dest_column → defaults to "{source}_embedding"
+        let def = EmbeddingDefinition::new("text", "test", None::<&str>);
+
+        let mem_table = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        let ctx = SessionContext::new();
+        ctx.register_table("t", Arc::new(mem_table)).unwrap();
+        let df = ctx.sql("SELECT * FROM t").await.unwrap();
+        let input = df.create_physical_plan().await.unwrap();
+
+        let result_plan = build_embedding_projection(input, &[(def, mock)]).unwrap();
+        let batches = collect(result_plan, ctx.task_ctx()).await.unwrap();
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].schema().field(1).name(), "text_embedding");
+    }
+}

--- a/rust/lancedb/src/table/datafusion/embedding_udf.rs
+++ b/rust/lancedb/src/table/datafusion/embedding_udf.rs
@@ -126,6 +126,18 @@ impl PhysicalExpr for EmbeddingPhysicalExpr {
     }
 }
 
+/// Compares two [`DataType`]s for compatibility, treating FSLs as equal if they
+/// have the same dimension and inner data type regardless of inner field name
+/// or nullability.
+fn fsl_compatible(a: &DataType, b: &DataType) -> bool {
+    match (a, b) {
+        (DataType::FixedSizeList(a_inner, a_dim), DataType::FixedSizeList(b_inner, b_dim)) => {
+            a_dim == b_dim && a_inner.data_type() == b_inner.data_type()
+        }
+        _ => a == b,
+    }
+}
+
 /// Builds a [`ProjectionExec`] that appends embedding columns to the input.
 ///
 /// For each embedding definition, creates an [`EmbeddingPhysicalExpr`] that
@@ -174,20 +186,16 @@ pub fn build_embedding_projection(
                 .dest_type()
                 .map_err(|e| DataFusionError::External(e.into()))?
                 .into_owned();
-            // Normalize FSL nullability for comparison (DataFusion normalizes to nullable)
-            let normalized_expected = match &expected_type {
-                DataType::FixedSizeList(inner, dim) => DataType::FixedSizeList(
-                    Arc::new(Field::new(inner.name(), inner.data_type().clone(), true)),
-                    *dim,
-                ),
-                other => other.clone(),
-            };
-            if *existing_field.data_type() != normalized_expected {
+            // Compare FSLs by dimension + inner data type only. Inner field names
+            // vary between schemas (e.g. "item" vs "values") and DataFusion
+            // normalizes inner fields to nullable, so neither name nor nullability
+            // should cause a mismatch.
+            if !fsl_compatible(existing_field.data_type(), &expected_type) {
                 return Err(DataFusionError::Plan(format!(
                     "existing column '{}' has type {:?}, but embedding function produces {:?}",
                     dest_name,
                     existing_field.data_type(),
-                    normalized_expected,
+                    expected_type,
                 )));
             }
             continue;
@@ -399,5 +407,43 @@ mod tests {
         let batches = collect(result_plan, ctx.task_ctx()).await.unwrap();
         assert_eq!(batches.len(), 1);
         assert_eq!(batches[0].schema().field(1).name(), "text_embedding");
+    }
+
+    #[tokio::test]
+    async fn test_build_projection_skips_existing_different_field_name() {
+        // Existing column has inner field "values" but embedding produces "item" —
+        // should still be considered compatible and skip.
+        let fsl_type =
+            DataType::FixedSizeList(Arc::new(Field::new("values", DataType::Float32, true)), 4);
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("text", DataType::Utf8, false),
+            Field::new("text_vec", fsl_type, true),
+        ]));
+
+        let inner_field = Arc::new(Field::new("values", DataType::Float32, true));
+        let values = Arc::new(arrow_array::Float32Array::from(vec![
+            1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0,
+        ]));
+        let fsl = arrow_array::FixedSizeListArray::new(inner_field, 4, values as ArrayRef, None);
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["hello", "world"])),
+                Arc::new(fsl) as ArrayRef,
+            ],
+        )
+        .unwrap();
+
+        let mock: Arc<dyn EmbeddingFunction> = Arc::new(MockEmbed::new("test", 4));
+        let def = EmbeddingDefinition::new("text", "test", Some("text_vec"));
+
+        let mem_table = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        let ctx = SessionContext::new();
+        ctx.register_table("t", Arc::new(mem_table)).unwrap();
+        let df = ctx.sql("SELECT * FROM t").await.unwrap();
+        let input = df.create_physical_plan().await.unwrap();
+
+        let result_plan = build_embedding_projection(input.clone(), &[(def, mock)]).unwrap();
+        assert!(Arc::ptr_eq(&result_plan, &input));
     }
 }

--- a/rust/lancedb/src/table/datafusion/embedding_udf.rs
+++ b/rust/lancedb/src/table/datafusion/embedding_udf.rs
@@ -4,6 +4,7 @@
 //! DataFusion physical expression and projection for computing embeddings.
 
 use std::any::Any;
+use std::collections::HashSet;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
@@ -154,13 +155,41 @@ pub fn build_embedding_projection(
         .collect();
 
     let mut added = false;
+    let mut seen_dest_names: HashSet<String> = HashSet::new();
     for (def, func) in embeddings {
         let dest_name = def
             .dest_column
             .clone()
             .unwrap_or_else(|| format!("{}_embedding", def.source_column));
 
-        if input_schema.field_with_name(&dest_name).is_ok() {
+        if !seen_dest_names.insert(dest_name.clone()) {
+            return Err(DataFusionError::Plan(format!(
+                "duplicate embedding destination column '{}'",
+                dest_name
+            )));
+        }
+
+        if let Ok(existing_field) = input_schema.field_with_name(&dest_name) {
+            let expected_type = func
+                .dest_type()
+                .map_err(|e| DataFusionError::External(e.into()))?
+                .into_owned();
+            // Normalize FSL nullability for comparison (DataFusion normalizes to nullable)
+            let normalized_expected = match &expected_type {
+                DataType::FixedSizeList(inner, dim) => DataType::FixedSizeList(
+                    Arc::new(Field::new(inner.name(), inner.data_type().clone(), true)),
+                    *dim,
+                ),
+                other => other.clone(),
+            };
+            if *existing_field.data_type() != normalized_expected {
+                return Err(DataFusionError::Plan(format!(
+                    "existing column '{}' has type {:?}, but embedding function produces {:?}",
+                    dest_name,
+                    existing_field.data_type(),
+                    normalized_expected,
+                )));
+            }
             continue;
         }
 
@@ -259,8 +288,50 @@ mod tests {
 
     #[tokio::test]
     async fn test_build_projection_skips_existing() {
+        let fsl_type =
+            DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), 4);
         let schema = Arc::new(Schema::new(vec![
             Field::new("text", DataType::Utf8, false),
+            Field::new("text_vec", fsl_type, true),
+        ]));
+
+        // Build an FSL column with the right type
+        use arrow_array::builder::{FixedSizeListBuilder, Float32Builder};
+        let mut fsl_builder = FixedSizeListBuilder::new(Float32Builder::with_capacity(8), 4);
+        for _ in 0..2 {
+            for v in &[1.0_f32, 2.0, 3.0, 4.0] {
+                fsl_builder.values().append_value(*v);
+            }
+            fsl_builder.append(true);
+        }
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["hello", "world"])),
+                Arc::new(fsl_builder.finish()) as ArrayRef,
+            ],
+        )
+        .unwrap();
+
+        let mock: Arc<dyn EmbeddingFunction> = Arc::new(MockEmbed::new("test", 4));
+        let def = EmbeddingDefinition::new("text", "test", Some("text_vec"));
+
+        let mem_table = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        let ctx = SessionContext::new();
+        ctx.register_table("t", Arc::new(mem_table)).unwrap();
+        let df = ctx.sql("SELECT * FROM t").await.unwrap();
+        let input = df.create_physical_plan().await.unwrap();
+
+        let result_plan = build_embedding_projection(input.clone(), &[(def, mock)]).unwrap();
+        // Should return input unchanged since dest column already exists
+        assert!(Arc::ptr_eq(&result_plan, &input));
+    }
+
+    #[tokio::test]
+    async fn test_build_projection_rejects_type_mismatch() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("text", DataType::Utf8, false),
+            // Existing column with wrong type (Float32 scalar instead of FSL)
             Field::new("text_vec", DataType::Float32, true),
         ]));
         let batch = RecordBatch::try_new(
@@ -281,9 +352,34 @@ mod tests {
         let df = ctx.sql("SELECT * FROM t").await.unwrap();
         let input = df.create_physical_plan().await.unwrap();
 
-        let result_plan = build_embedding_projection(input.clone(), &[(def, mock)]).unwrap();
-        // Should return input unchanged since dest column already exists
-        assert!(Arc::ptr_eq(&result_plan, &input));
+        let result = build_embedding_projection(input, &[(def, mock)]);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("text_vec"), "error should mention column name");
+    }
+
+    #[tokio::test]
+    async fn test_build_projection_rejects_duplicate_dest() {
+        let (schema, batch) = make_text_batch();
+        let mock1: Arc<dyn EmbeddingFunction> = Arc::new(MockEmbed::new("test1", 4));
+        let mock2: Arc<dyn EmbeddingFunction> = Arc::new(MockEmbed::new("test2", 4));
+        let def1 = EmbeddingDefinition::new("text", "test1", Some("output"));
+        let def2 = EmbeddingDefinition::new("text", "test2", Some("output"));
+
+        let mem_table = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+        let ctx = SessionContext::new();
+        ctx.register_table("t", Arc::new(mem_table)).unwrap();
+        let df = ctx.sql("SELECT * FROM t").await.unwrap();
+        let input = df.create_physical_plan().await.unwrap();
+
+        let result = build_embedding_projection(input, &[(def1, mock1), (def2, mock2)]);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("duplicate"),
+            "error should mention duplicate: {}",
+            err
+        );
     }
 
     #[tokio::test]

--- a/rust/lancedb/src/table/datafusion/preprocessing.rs
+++ b/rust/lancedb/src/table/datafusion/preprocessing.rs
@@ -342,6 +342,120 @@ mod tests {
         assert_eq!(batches[0].num_rows(), 2);
     }
 
+    fn list_f32_schema(dim_hint: &str) -> Arc<Schema> {
+        let _ = dim_hint; // just for readability at call sites
+        Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new(
+                "vec",
+                DataType::List(Arc::new(Field::new("item", DataType::Float32, true))),
+                true,
+            ),
+        ]))
+    }
+
+    fn make_list_f32(values: &[Option<Vec<f32>>]) -> ArrayRef {
+        use arrow_array::builder::{Float32Builder, ListBuilder};
+        let mut builder = ListBuilder::new(Float32Builder::new());
+        for row in values {
+            match row {
+                Some(vals) => {
+                    for v in vals {
+                        builder.values().append_value(*v);
+                    }
+                    builder.append(true);
+                }
+                None => {
+                    builder.append(false);
+                }
+            }
+        }
+        Arc::new(builder.finish())
+    }
+
+    fn make_large_list_f32(values: &[Option<Vec<f32>>]) -> ArrayRef {
+        use arrow_array::builder::{Float32Builder, LargeListBuilder};
+        let mut builder = LargeListBuilder::new(Float32Builder::new());
+        for row in values {
+            match row {
+                Some(vals) => {
+                    for v in vals {
+                        builder.values().append_value(*v);
+                    }
+                    builder.append(true);
+                }
+                None => {
+                    builder.append(false);
+                }
+            }
+        }
+        Arc::new(builder.finish())
+    }
+
+    #[tokio::test]
+    async fn test_null_strategy_list() {
+        let schema = list_f32_schema("3");
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                make_list_f32(&[
+                    Some(vec![1.0, 2.0, 3.0]),
+                    Some(vec![f32::NAN, 5.0, 6.0]),
+                    Some(vec![7.0, 8.0, 9.0]),
+                ]),
+            ],
+        )
+        .unwrap();
+
+        let batches = run_preprocessing(schema, batch, NanStrategy::Null)
+            .await
+            .unwrap();
+        assert_eq!(batches.len(), 1);
+        let result = &batches[0];
+        assert_eq!(result.num_rows(), 3);
+        let col = result.column(1);
+        assert!(!col.is_null(0));
+        assert!(col.is_null(1)); // NaN row → null
+        assert!(!col.is_null(2));
+    }
+
+    #[tokio::test]
+    async fn test_drop_strategy_large_list() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new(
+                "vec",
+                DataType::LargeList(Arc::new(Field::new("item", DataType::Float32, true))),
+                true,
+            ),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                make_large_list_f32(&[
+                    Some(vec![1.0, 2.0, 3.0]),
+                    Some(vec![f32::NAN, 5.0, 6.0]),
+                    Some(vec![7.0, 8.0, 9.0]),
+                ]),
+            ],
+        )
+        .unwrap();
+
+        let batches = run_preprocessing(schema, batch, NanStrategy::Drop)
+            .await
+            .unwrap();
+        let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total_rows, 2);
+
+        let ids = batches[0]
+            .column(0)
+            .as_primitive::<arrow_array::types::Int32Type>();
+        assert_eq!(ids.value(0), 1);
+        assert_eq!(ids.value(1), 3);
+    }
+
     #[tokio::test]
     async fn test_clean_data_passthrough() {
         let schema = fsl_schema(3);

--- a/rust/lancedb/src/table/datafusion/preprocessing.rs
+++ b/rust/lancedb/src/table/datafusion/preprocessing.rs
@@ -1,0 +1,363 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The LanceDB Authors
+
+//! DataFusion ExecutionPlan node for NaN handling in float vector columns.
+
+use std::any::Any;
+use std::sync::Arc;
+
+use arrow_schema::SchemaRef;
+use datafusion_common::{DataFusionError, Result as DataFusionResult};
+use datafusion_execution::{SendableRecordBatchStream, TaskContext};
+use datafusion_physical_expr::EquivalenceProperties;
+use datafusion_physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion_physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
+use futures::TryStreamExt;
+
+use crate::data::preprocessing::{find_float_vector_columns, handle_nan_batch, NanStrategy};
+
+/// Streaming plan node that handles NaN values in float vector columns.
+///
+/// Applies a [`NanStrategy`] to every batch, processing all float vector
+/// columns (`FixedSizeList`, `List`, `LargeList` with float elements).
+#[derive(Debug)]
+pub struct PreprocessingExec {
+    input: Arc<dyn ExecutionPlan>,
+    strategy: NanStrategy,
+    vec_col_indices: Vec<usize>,
+    properties: PlanProperties,
+}
+
+impl PreprocessingExec {
+    pub fn new(input: Arc<dyn ExecutionPlan>, strategy: NanStrategy) -> Self {
+        let schema = input.schema();
+        let vec_col_indices = find_float_vector_columns(&schema);
+        let properties = Self::compute_properties(&input, &schema);
+        Self {
+            input,
+            strategy,
+            vec_col_indices,
+            properties,
+        }
+    }
+
+    fn compute_properties(input: &Arc<dyn ExecutionPlan>, schema: &SchemaRef) -> PlanProperties {
+        let input_props = input.properties();
+        let eq_properties = EquivalenceProperties::new(schema.clone());
+        PlanProperties::new(
+            eq_properties,
+            input_props.output_partitioning().clone(),
+            match input_props.emission_type {
+                EmissionType::Incremental => EmissionType::Incremental,
+                EmissionType::Final => EmissionType::Final,
+                EmissionType::Both => EmissionType::Both,
+            },
+            match input_props.boundedness {
+                Boundedness::Bounded => Boundedness::Bounded,
+                other => other,
+            },
+        )
+    }
+}
+
+impl DisplayAs for PreprocessingExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default | DisplayFormatType::Verbose => {
+                write!(
+                    f,
+                    "PreprocessingExec: strategy={:?}, vec_cols={:?}",
+                    self.strategy, self.vec_col_indices
+                )
+            }
+            DisplayFormatType::TreeRender => {
+                write!(f, "PreprocessingExec")
+            }
+        }
+    }
+}
+
+impl ExecutionPlan for PreprocessingExec {
+    fn name(&self) -> &str {
+        "PreprocessingExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn maintains_input_order(&self) -> Vec<bool> {
+        vec![true]
+    }
+
+    fn benefits_from_input_partitioning(&self) -> Vec<bool> {
+        vec![false]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        if children.len() != 1 {
+            return Err(DataFusionError::Internal(
+                "PreprocessingExec requires exactly one child".to_string(),
+            ));
+        }
+        Ok(Arc::new(Self::new(
+            children[0].clone(),
+            self.strategy.clone(),
+        )))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> DataFusionResult<SendableRecordBatchStream> {
+        let input_stream = self.input.execute(partition, context)?;
+
+        if self.vec_col_indices.is_empty() {
+            return Ok(input_stream);
+        }
+
+        let schema = self.input.schema();
+        let strategy = self.strategy.clone();
+        let vec_cols = self.vec_col_indices.clone();
+
+        let stream = input_stream
+            .map_ok(move |batch| handle_nan_batch(batch, &vec_cols, &strategy, &schema));
+
+        // Flatten the Result<Result<RecordBatch>> into Result<RecordBatch>
+        let stream = stream.and_then(|result| async move {
+            result.map_err(|e| DataFusionError::External(e.into()))
+        });
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            self.input.schema(),
+            stream,
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_array::builder::{FixedSizeListBuilder, Float32Builder};
+    use arrow_array::cast::AsArray;
+    use arrow_array::types::Float32Type;
+    use arrow_array::{Array, ArrayRef, Int32Array, RecordBatch};
+    use arrow_schema::{DataType, Field, Schema};
+    use datafusion::prelude::SessionContext;
+    use datafusion_catalog::MemTable;
+    use datafusion_physical_plan::collect;
+
+    fn make_fsl_f32(values: &[Option<Vec<f32>>], dim: i32) -> ArrayRef {
+        let dim_usize = dim as usize;
+        let n = values.len();
+        let mut builder =
+            FixedSizeListBuilder::new(Float32Builder::with_capacity(n * dim_usize), dim);
+        for row in values {
+            match row {
+                Some(vals) => {
+                    for v in vals {
+                        builder.values().append_value(*v);
+                    }
+                    builder.append(true);
+                }
+                None => {
+                    for _ in 0..dim_usize {
+                        builder.values().append_null();
+                    }
+                    builder.append(false);
+                }
+            }
+        }
+        Arc::new(builder.finish())
+    }
+
+    fn fsl_schema(dim: i32) -> Arc<Schema> {
+        Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new(
+                "vec",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), dim),
+                true,
+            ),
+        ]))
+    }
+
+    async fn run_preprocessing(
+        schema: Arc<Schema>,
+        batch: RecordBatch,
+        strategy: NanStrategy,
+    ) -> DataFusionResult<Vec<RecordBatch>> {
+        let mem_table = MemTable::try_new(schema, vec![vec![batch]])?;
+        let ctx = SessionContext::new();
+        ctx.register_table("t", Arc::new(mem_table))?;
+        let df = ctx.sql("SELECT * FROM t").await?;
+        let input = df.create_physical_plan().await?;
+        let preprocessing = Arc::new(PreprocessingExec::new(input, strategy));
+        collect(preprocessing, ctx.task_ctx()).await
+    }
+
+    #[tokio::test]
+    async fn test_error_strategy() {
+        let schema = fsl_schema(3);
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])),
+                make_fsl_f32(
+                    &[Some(vec![1.0, 2.0, 3.0]), Some(vec![f32::NAN, 5.0, 6.0])],
+                    3,
+                ),
+            ],
+        )
+        .unwrap();
+
+        let result = run_preprocessing(schema, batch, NanStrategy::Error).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_drop_strategy() {
+        let schema = fsl_schema(3);
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                make_fsl_f32(
+                    &[
+                        Some(vec![1.0, 2.0, 3.0]),
+                        Some(vec![f32::NAN, 5.0, 6.0]),
+                        Some(vec![7.0, 8.0, 9.0]),
+                    ],
+                    3,
+                ),
+            ],
+        )
+        .unwrap();
+
+        let batches = run_preprocessing(schema, batch, NanStrategy::Drop)
+            .await
+            .unwrap();
+        let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total_rows, 2);
+
+        let ids = batches[0]
+            .column(0)
+            .as_primitive::<arrow_array::types::Int32Type>();
+        assert_eq!(ids.value(0), 1);
+        assert_eq!(ids.value(1), 3);
+    }
+
+    #[tokio::test]
+    async fn test_null_strategy() {
+        let schema = fsl_schema(3);
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                make_fsl_f32(
+                    &[
+                        Some(vec![1.0, 2.0, 3.0]),
+                        Some(vec![f32::NAN, 5.0, 6.0]),
+                        Some(vec![7.0, 8.0, 9.0]),
+                    ],
+                    3,
+                ),
+            ],
+        )
+        .unwrap();
+
+        let batches = run_preprocessing(schema, batch, NanStrategy::Null)
+            .await
+            .unwrap();
+        assert_eq!(batches.len(), 1);
+        let result = &batches[0];
+        assert_eq!(result.num_rows(), 3);
+        let fsl = result.column(1).as_fixed_size_list();
+        assert!(!fsl.is_null(0));
+        assert!(fsl.is_null(1)); // NaN row → null
+        assert!(!fsl.is_null(2));
+    }
+
+    #[tokio::test]
+    async fn test_fill_strategy() {
+        let schema = fsl_schema(3);
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])),
+                make_fsl_f32(
+                    &[Some(vec![1.0, 2.0, 3.0]), Some(vec![f32::NAN, 5.0, 6.0])],
+                    3,
+                ),
+            ],
+        )
+        .unwrap();
+
+        let batches = run_preprocessing(schema, batch, NanStrategy::Fill(0.0))
+            .await
+            .unwrap();
+        assert_eq!(batches.len(), 1);
+        let result = &batches[0];
+        assert_eq!(result.num_rows(), 2);
+        let fsl = result.column(1).as_fixed_size_list();
+        let row1 = fsl.value(1);
+        let vals = row1.as_primitive::<Float32Type>();
+        assert_eq!(vals.value(0), 0.0); // was NaN, now 0.0
+        assert_eq!(vals.value(1), 5.0);
+        assert_eq!(vals.value(2), 6.0);
+    }
+
+    #[tokio::test]
+    async fn test_no_vector_cols_passthrough() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])),
+                Arc::new(arrow_array::StringArray::from(vec!["a", "b"])),
+            ],
+        )
+        .unwrap();
+
+        let batches = run_preprocessing(schema, batch, NanStrategy::Error)
+            .await
+            .unwrap();
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].num_rows(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_clean_data_passthrough() {
+        let schema = fsl_schema(3);
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])),
+                make_fsl_f32(&[Some(vec![1.0, 2.0, 3.0]), Some(vec![4.0, 5.0, 6.0])], 3),
+            ],
+        )
+        .unwrap();
+
+        let batches = run_preprocessing(schema, batch, NanStrategy::Error)
+            .await
+            .unwrap();
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].num_rows(), 2);
+    }
+}


### PR DESCRIPTION
## Summary

- Add DataFusion `ExecutionPlan` nodes for vector casting (`CastVectorExec`), embedding generation (`EmbeddingUdfExec`), and NaN/Inf preprocessing (`PreprocessingExec`).
- Add `NativeInsertExec` for local table inserts via DataFusion.
- Wire `TableProvider::insert_into()` so DataFusion SQL `INSERT INTO` works for both local and remote tables.
- Tighten FSL cast and embedding type validation.

## Test plan

- [x] Unit tests for `CastVectorExec` (dimension inference, type coercion, nullability)
- [x] Unit tests for `EmbeddingUdfExec` (mock embedding function, schema projection)
- [x] Unit tests for `PreprocessingExec` (NaN handling modes)
- [x] Unit tests for `NativeInsertExec` and `RemoteInsertExec`
- [x] `cargo clippy` and `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)